### PR TITLE
Compile sketches on every PR

### DIFF
--- a/src/run_tests.sh
+++ b/src/run_tests.sh
@@ -7,7 +7,7 @@ ocamlbuild -Is ast,parse,lib,codegen -package batteries -package cryptokit -pack
 ./codegen_test.native || exit 1
 ./lib_test.native || exit 1
 ./hex_test.native || exit 1
-for f in `ls parse/examples/*.bbo`
+for f in `ls parse/examples/*.bbo ../sketch/*.bbo`
 do
   echo "trying" $f
   cat $f | ./parser_test.native || \


### PR DESCRIPTION
This is a follow-up to #88.  Whenever the compiler changes, the `sketch/*.bbo` sources should be tested as well.