### PR TITLE
Use the new numeric literals in the vault example

### DIFF
--- a/src/parse/examples/024_vault.bbo
+++ b/src/parse/examples/024_vault.bbo
@@ -1,29 +1,31 @@
 // Based on http://www.blunderingcode.com/ether-vaults/
 
 // The argument unvaultPeriod should disappear and instead a constant four weeks should be used.
-contract Vault(address hotwallet, address vaultKey, address recoveryKey, uint256 unvaultPeriod) {
+contract Vault(address hotwallet, address vaultKey, address recoveryKey) {
   case(void unvault(uint256 amount)) {
     if (sender(msg) != vaultKey) abort;
-    return then become UnVaulting(now(block) + unvaultPeriod, amount, hotwallet, vaultKey, recoveryKey, unvaultPeriod);
+    uint256 unvaultPeriod = 60 * 60 * 24 * 7 * 2; // two weeks
+    if (now(block) + unvaultPeriod > now(block)) abort;
+    return then become UnVaulting(now(block) + unvaultPeriod, amount, hotwallet, vaultKey, recoveryKey);
   }
   case(void recover(address _newHotWallet)) {
     if (sender(msg) != recoveryKey) abort;
-    return then become Vault(_newHotWallet, vaultKey, recoveryKey, unvaultPeriod);
+    return then become Vault(_newHotWallet, vaultKey, recoveryKey);
   }
   case(void destroy()) {
     return then become Destroyed();
   }
 }
 
-contract UnVaulting(uint256 redeemtime, uint256 amount, address hotwallet, address vaultKey, address recoveryKey, uint256 unvaultPeriod) {
+contract UnVaulting(uint256 redeemtime, uint256 amount, address hotwallet, address vaultKey, address recoveryKey) {
   case(void redeem()) {
     if (amount > balance(this)) abort;
     void = hotwallet.default() with amount reentrance { abort; };
-    return then become Vault(hotwallet, vaultKey, recoveryKey, unvaultPeriod);
+    return then become Vault(hotwallet, vaultKey, recoveryKey);
   }
   case(void recover(address _newHotWallet)) {
     if (sender(msg) != recoveryKey) abort;
-    return then become Vault(_newHotWallet, vaultKey, recoveryKey, unvaultPeriod);
+    return then become Vault(_newHotWallet, vaultKey, recoveryKey);
   }
   case(void destroy()) {
     return then become Destroyed();


### PR DESCRIPTION
Using the new numeric literals, I can give a concrete unvaulting period of two weeks.

This makes the program simpler and closer to the original Solidity code.