### PR TITLE
Run `make` many times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ install:
 - npm install
 script:
 - make doc/spec.pdf
-- make; make; make; make
+- make; make; make; make; make; make; make; make
 - make test
 - which eth
 - eth --version


### PR DESCRIPTION
because locally, make eventually succeeds.

The root cause seems to some missing build dependency around Lexer.ml and Parser.ml